### PR TITLE
LazyVar needs to be fully qualified

### DIFF
--- a/src/borkdude/dynaload_cljs.cljc
+++ b/src/borkdude/dynaload_cljs.cljc
@@ -1,7 +1,7 @@
 (ns borkdude.dynaload-cljs)
 
 (defmacro dynaload [[_quote s]]
-  `(LazyVar.
+  `(borkdude.dynaload-cljs/LazyVar.
     (fn []
       (if (cljs.core/exists? ~s)
         ~(vary-meta s assoc :cljs.analyzer/no-resolve true)


### PR DESCRIPTION
otherwise, resolves into caller ns.