### PR TITLE
fix(bb): return cached value instead of Volatile in deref

### DIFF
--- a/src/borkdude/dynaload.cljc
+++ b/src/borkdude/dynaload.cljc
@@ -16,7 +16,7 @@
              clojure.lang.IDeref
              (deref [_this]
                (if-not (nil? @cached)
-                 cached
+                 @cached
                  (let [x (f)]
                    (when-not (nil? x)
                      (vreset! cached x))

--- a/test/borkdude/dynaload_test.cljc
+++ b/test/borkdude/dynaload_test.cljc
@@ -7,12 +7,14 @@
 
 (deftest dynaload-test
   (let [f (dynaload 'borkdude.lib/foo)]
-    (is (= 1 (f))))
+    (is (= 1 (f)))
+    (is (= 1 (f)) "cached result should work on second call"))
   (is (thrown-with-msg?
        #?(:clj Exception :cljs js/Error)
        #"borkdude.bar" ((dynaload 'borkdude.bar/foo))))
   (let [f (dynaload 'borkdude.bar/foo {:default (fn [] 1)})]
-    (is (= 1 (f))))
+    (is (= 1 (f)))
+    (is (= 1 (f)) "cached default should work on second call"))
   (let [f (dynaload 'borkdude.bar/foo {:default (fn [])})]
     (is (nil? (f))))
   (testing "nothing happens when you don't use it"


### PR DESCRIPTION
## Summary
- Fix Babashka's reify deref implementation to return `@cached` instead of `cached`
- Add tests that call dynaload results twice to catch caching bugs
- Prevents `ClassCastException: clojure.lang.Volatile cannot be cast to clojure.lang.IFn`

## Problem
In Babashka's `->LazyVar` reify implementation, the `deref` method was returning the Volatile object itself (`cached`) instead of its dereferenced contents (`@cached`). This caused a `ClassCastException` when a dynaload result was invoked more than once, as the second call would try to invoke the Volatile as a function.

## Test plan
- [x] Run `bb test:bb` to verify Babashka tests pass
- [x] Run `bb test:clj` to verify JVM tests still pass
- [x] Run `bb test:cljs` to verify ClojureScript tests still pass